### PR TITLE
Add VS Glass extension

### DIFF
--- a/README-BR.md
+++ b/README-BR.md
@@ -49,6 +49,7 @@ Algumas das ferramentas abaixo me ajudaram muito quando eu precisei. Sinta-se li
 - [HTML CSS Support](https://marketplace.visualstudio.com/items?itemName=ecmel.vscode-html-css): Conclusão de classes e IDs para HTML com suporte para arquivos CSS (CDN) remotos.
 - [VSCode Spotify](https://marketplace.visualstudio.com/items?itemName=shyykoserhiy.vscode-spotify): Use o Spotify dentro do vscode. Fornece integração com o cliente Spotify Desktop.
 - [Discord Presence](https://marketplace.visualstudio.com/items?itemName=icrawl.discord-vscode): Mostre em seu status do Discord que está programando no VSCode com uma linguagem específica (automaticamente.)
+- [Glassit-VSC](https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit): Extensão de código VS para definir a janela como transparente na plataforma Windows.
 
 ### Comandos úteis
 - `npx add-gitignore` para adicionar um arquivo git ignore ao seu projeto para uma linguagem específica.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ modern web projects.
 - [HTML CSS Support](https://marketplace.visualstudio.com/items?itemName=ecmel.vscode-html-css): Class and ID completion for HTML with support for remote CSS files (CDN).
 - [VSCode Spotify](https://marketplace.visualstudio.com/items?itemName=shyykoserhiy.vscode-spotify): Use Spotify inside vscode. Provides integration with Spotify Desktop client.
 - [Discord Presence](https://marketplace.visualstudio.com/items?itemName=icrawl.discord-vscode): Update your discord status with the newly added rich presence.
+- [Glassit-VSC](https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit):VS Code Extension to set window to transparent on Windows platform.
+
 
 ### Useful commands
 - `npx add-gitignore` for adding a git ignore file to your project for a specific language


### PR DESCRIPTION
- [Glassit-VSC](https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit):VS Code Extension to set window to transparent on Windows platform.